### PR TITLE
Advanced option to keep internal .git files when exporting the source code

### DIFF
--- a/Git/Common/Clients/CommandLine/GitCommandLineClient.cs
+++ b/Git/Common/Clients/CommandLine/GitCommandLineClient.cs
@@ -158,9 +158,9 @@ namespace Inedo.Extensions.Clients.CommandLine
             await this.ExecuteCommandLineAsync(pushArgs, this.repository.LocalRepositoryPath).ConfigureAwait(false);
         }
 
-        public override Task ArchiveAsync(string targetDirectory)
+        public override Task ArchiveAsync(string targetDirectory, bool keepInternals = false)
         {
-            return CopyNonGitFilesAsync(this.fileOps, this.repository.LocalRepositoryPath, targetDirectory);
+            return CopyFilesAsync(this.fileOps, this.repository.LocalRepositoryPath, targetDirectory, keepInternals);
         }
 
         private async Task<ProcessResults> ExecuteCommandLineAsync(GitArgumentsBuilder args, string workingDirectory, bool throwOnFailure = true)

--- a/Git/Common/Clients/GitClient.cs
+++ b/Git/Common/Clients/GitClient.cs
@@ -22,18 +22,18 @@ namespace Inedo.Extensions.Clients
         public abstract Task<bool> IsRepositoryValidAsync();
         public abstract Task CloneAsync(GitCloneOptions options);
         public abstract Task<string> UpdateAsync(GitUpdateOptions options);
-        public abstract Task ArchiveAsync(string targetDirectory);
+        public abstract Task ArchiveAsync(string targetDirectory, bool keepInternals = false);
         public abstract Task<IEnumerable<string>> EnumerateRemoteBranchesAsync();
         public abstract Task TagAsync(string tag, string commit, string message);
 
-        protected static async Task CopyNonGitFilesAsync(IFileOperationsExecuter fileOps, string sourceDirectory, string targetDirectory)
+        protected static async Task CopyFilesAsync(IFileOperationsExecuter fileOps, string sourceDirectory, string targetDirectory, bool keepInternals = false)
         {
             if (!await fileOps.DirectoryExistsAsync(sourceDirectory).ConfigureAwait(false))
                 return;
 
             char separator = fileOps.DirectorySeparator;
 
-            var infos = await fileOps.GetFileSystemInfosAsync(sourceDirectory, new MaskingContext(new[] { "**" }, new[] { "**" + separator + ".git**" })).ConfigureAwait(false);
+            var infos = await fileOps.GetFileSystemInfosAsync(sourceDirectory, keepInternals ? MaskingContext.IncludeAll : new MaskingContext(new[] { "**" }, new[] { "**" + separator + ".git**" })).ConfigureAwait(false);
 
             var directoriesToCreate = infos.OfType<SlimDirectoryInfo>().Select(d => CombinePaths(targetDirectory, d.FullName.Substring(sourceDirectory.Length), separator)).ToArray();
             var relativeFileNames = infos.OfType<SlimFileInfo>().Select(f => f.FullName.Substring(sourceDirectory.Length).TrimStart(separator)).ToArray();

--- a/Git/Common/Clients/LibGitSharp/LibGitSharpClient.cs
+++ b/Git/Common/Clients/LibGitSharp/LibGitSharpClient.cs
@@ -231,9 +231,9 @@ namespace Inedo.Extensions.Clients.LibGitSharp
             }
         }
 
-        public override Task ArchiveAsync(string targetDirectory)
+        public override Task ArchiveAsync(string targetDirectory, bool keepInternals = false)
         {
-            return CopyNonGitFilesAsync(new FileArchiver(targetDirectory), this.repository.LocalRepositoryPath, targetDirectory);
+            return CopyFilesAsync(new FileArchiver(targetDirectory), this.repository.LocalRepositoryPath, targetDirectory, keepInternals);
         }
 
         private LibGit2Sharp.Credentials CredentialsHandler(string url, string usernameFromUrl, SupportedCredentialTypes types)

--- a/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpClient.cs
+++ b/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpClient.cs
@@ -29,11 +29,11 @@ namespace Inedo.Extensions.Clients.LibGitSharp.Remote
             this.cancellationToken = cancellationToken;
         }
 
-        public override Task ArchiveAsync(string targetDirectory)
+        public override Task ArchiveAsync(string targetDirectory, bool keepInternals = false)
         {
             return this.ExecuteRemoteAsync(
                 ClientCommand.Archive,
-                new RemoteLibGitSharpContext { TargetDirectory = targetDirectory }
+                new RemoteLibGitSharpContext { TargetDirectory = targetDirectory, KeepInternals = keepInternals }
             );
         }
 

--- a/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpContext.cs
+++ b/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpContext.cs
@@ -18,6 +18,7 @@ namespace Inedo.Extensions.Clients.LibGitSharp.Remote
         public string Password { get; set; }
 
         public string TargetDirectory { get; set; }
+        public bool KeepInternals { get; set; }
         public GitCloneOptions CloneOptions { get; set; }
         public string Tag { get; set; }
         public string Commit { get; set; }

--- a/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpJob.cs
+++ b/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpJob.cs
@@ -31,7 +31,7 @@ namespace Inedo.Extensions.Clients.LibGitSharp.Remote
             switch (this.Command)
             {
                 case ClientCommand.Archive:
-                    await client.ArchiveAsync(this.Context.TargetDirectory).ConfigureAwait(false);
+                    await client.ArchiveAsync(this.Context.TargetDirectory, this.Context.KeepInternals).ConfigureAwait(false);
                     return null;
 
                 case ClientCommand.Clone:
@@ -45,7 +45,7 @@ namespace Inedo.Extensions.Clients.LibGitSharp.Remote
                     return await client.IsRepositoryValidAsync().ConfigureAwait(false);
 
                 case ClientCommand.Tag:
-                    await client.TagAsync(this.Context.Tag, this.Context.Commit, this.Context.TagMessage);
+                    await client.TagAsync(this.Context.Tag, this.Context.Commit, this.Context.TagMessage).ConfigureAwait(false);
                     return null;
 
                 case ClientCommand.Update:

--- a/Git/Common/Operations/GetSourceOperation.cs
+++ b/Git/Common/Operations/GetSourceOperation.cs
@@ -45,6 +45,12 @@ namespace Inedo.Extensions.Operations
         [Description("The full SHA1 hash of the fetched commit will be stored in this variable.")]
         public string CommitHash { get; set; }
 
+        [Category("Advanced")]
+        [ScriptAlias("KeepInternals")]
+        [DisplayName("Copy internal Git files")]
+        [Description("When exporting the repository, also export .git* files.")]
+        public bool KeepInternals { get; set; }
+
         public override async Task ExecuteAsync(IOperationExecutionContext context)
         {
             string repositoryUrl = await this.GetRepositoryUrlAsync().ConfigureAwait(false);
@@ -91,7 +97,7 @@ namespace Inedo.Extensions.Operations
 
             this.LogDebug($"Current commit is {this.CommitHash}.");
 
-            await client.ArchiveAsync(context.ResolvePath(this.DiskPath)).ConfigureAwait(false);
+            await client.ArchiveAsync(context.ResolvePath(this.DiskPath), this.KeepInternals).ConfigureAwait(false);
 
             this.LogInformation("Get source complete.");
         }


### PR DESCRIPTION
Some build scripts expect the repository to be present when building for a metadata-collection step. This makes it easier to use BuildMaster with those pre-existing build scripts.