### PR TITLE
Fix GitHub release asset uploads displaying the progress of loading the file into the buffer instead of actual upload progress.

### DIFF
--- a/Git/GitHub.InedoExtension/Clients/GitHubClient.cs
+++ b/Git/GitHub.InedoExtension/Clients/GitHubClient.cs
@@ -181,6 +181,15 @@ namespace Inedo.Extensions.Clients
 
             var request = this.CreateRequest("POST", uploadUrl);
             request.ContentType = contentType;
+            request.AllowWriteStreamBuffering = false;
+            try
+            {
+                request.ContentLength = contents.Length;
+            }
+            catch
+            {
+                request.SendChunked = true;
+            }
 
             using (cancellationToken.Register(() => request.Abort()))
             {


### PR DESCRIPTION
On my local setup, it takes about 90 seconds to upload a 16MB file, but the bar filled in about half a second because the entire file was loaded into a buffer and then sent when the request stream was closed.

Fixes #39.