### PR TITLE
Fixed issues with Git Rafts using branches other than master

### DIFF
--- a/Git/Git.InedoExtension/RaftRepositories/ExternalGitRaftRepository.cs
+++ b/Git/Git.InedoExtension/RaftRepositories/ExternalGitRaftRepository.cs
@@ -73,15 +73,18 @@ namespace Inedo.Extensions.RaftRepositories
 
                     if (!string.IsNullOrEmpty(this.RemoteRepositoryUrl))
                     {
-                        Commands.Fetch(repository, "origin", Enumerable.Empty<string>(), new FetchOptions { CredentialsProvider = CredentialsHandler }, null);
+
+                        Commands.Fetch(repository, "origin", Enumerable.Empty<string>(), 
+                            new FetchOptions { CredentialsProvider = CredentialsHandler }, null);
+
                         if (repository.Refs["refs/heads/" + this.BranchName] == null)
                         {
-                            repository.Refs.Add("refs/heads/" + this.BranchName, "refs/remotes/origin/" + this.BranchName);
+                            //Must use an ObjectId to create a DirectReference (SymbolicReferences will cause an error when committing)
+                            var objId = new ObjectId(repository.Refs["refs/remotes/origin/" + this.BranchName].TargetIdentifier);
+                            repository.Refs.Add("refs/heads/" + this.BranchName, objId);
                         }
-                        else
-                        {
-                            repository.Refs.UpdateTarget("refs/heads/" + this.BranchName, "refs/remotes/origin/" + this.BranchName);
-                        }
+
+                        repository.Refs.UpdateTarget("refs/heads/" + this.BranchName, "refs/remotes/origin/" + this.BranchName);
                     }
 
                     return repository;

--- a/Git/Git.InedoExtension/RaftRepositories/ExternalGitRaftRepository.cs
+++ b/Git/Git.InedoExtension/RaftRepositories/ExternalGitRaftRepository.cs
@@ -73,17 +73,14 @@ namespace Inedo.Extensions.RaftRepositories
 
                     if (!string.IsNullOrEmpty(this.RemoteRepositoryUrl))
                     {
-
                         Commands.Fetch(repository, "origin", Enumerable.Empty<string>(), 
                             new FetchOptions { CredentialsProvider = CredentialsHandler }, null);
-
                         if (repository.Refs["refs/heads/" + this.BranchName] == null)
                         {
                             //Must use an ObjectId to create a DirectReference (SymbolicReferences will cause an error when committing)
                             var objId = new ObjectId(repository.Refs["refs/remotes/origin/" + this.BranchName].TargetIdentifier);
                             repository.Refs.Add("refs/heads/" + this.BranchName, objId);
                         }
-
                         repository.Refs.UpdateTarget("refs/heads/" + this.BranchName, "refs/remotes/origin/" + this.BranchName);
                     }
 

--- a/Git/Git.InedoExtension/RaftRepositories/GitRaftRepositoryBase.cs
+++ b/Git/Git.InedoExtension/RaftRepositories/GitRaftRepositoryBase.cs
@@ -48,7 +48,7 @@ namespace Inedo.Extensions.RaftRepositories
         private protected bool Dirty => this.dirty;
         private protected Repository Repo => this.lazyRepository.Value;
 
-         private bool OptimizeLoadTime => (this.OpenOptions & OpenRaftOptions.OptimizeLoadTime) != 0;
+        private bool OptimizeLoadTime => (this.OpenOptions & OpenRaftOptions.OptimizeLoadTime) != 0;
         private string RepositoryRoot { get; set; }
 
         public sealed override Task<IEnumerable<RaftItem>> GetRaftItemsAsync()
@@ -61,7 +61,6 @@ namespace Inedo.Extensions.RaftRepositories
             IEnumerable<RaftItem> inner()
             {
                 var repo = this.lazyRepository.Value;
-               
                 var tip = repo.Branches[this.BranchName]?.Tip;
                 if (tip == null)
                     yield break;
@@ -102,7 +101,6 @@ namespace Inedo.Extensions.RaftRepositories
                                             SortBy = CommitSortStrategies.Time }
                                         );
                                     var commit = commits.FirstOrDefault();
-
                                     if (commit != null)
                                     {
                                         var committer = commit.Commit.Committer;
@@ -259,7 +257,6 @@ namespace Inedo.Extensions.RaftRepositories
                         FirstParentOnly = true,
                         SortBy = CommitSortStrategies.Time
                     });
-
                     foreach (var c in commits)
                     {
                         var commit = c.Commit;


### PR DESCRIPTION
1) Can now create new assets
2) Can now list assets
3) Can now display version history

In order to support creating new assets on a branch different than master, just needed to add a "DirectReference" instead of a "SymbolicReference" to the Refs collection of the repo.

Also, in order to support displaying the assets on a branch other than master, just needed to specify the branch when querying the commits.  This same code was used to make the version history work as well.