### PR TITLE
Improve rafts

### DIFF
--- a/Git/Common/Clients/CommandLine/GitArgumentsBuilder.cs
+++ b/Git/Common/Clients/CommandLine/GitArgumentsBuilder.cs
@@ -5,7 +5,7 @@ namespace Inedo.Extensions.Clients.CommandLine
 {
     internal sealed class GitArgumentsBuilder
     {
-        private List<GitArg> arguments = new List<GitArg>(16);
+        private readonly List<GitArg> arguments = new List<GitArg>(16);
 
         public GitArgumentsBuilder()
         {
@@ -25,9 +25,9 @@ namespace Inedo.Extensions.Clients.CommandLine
 
         private sealed class GitArg
         {
-            private bool quoted;
-            private bool sensitive;
-            private string arg;
+            private readonly bool quoted;
+            private readonly bool sensitive;
+            private readonly string arg;
 
             public GitArg(string arg, bool quoted, bool sensitive)
             {

--- a/Git/Common/Clients/GitClient.cs
+++ b/Git/Common/Clients/GitClient.cs
@@ -22,6 +22,7 @@ namespace Inedo.Extensions.Clients
         public abstract Task<bool> IsRepositoryValidAsync();
         public abstract Task CloneAsync(GitCloneOptions options);
         public abstract Task<string> UpdateAsync(GitUpdateOptions options);
+        public abstract Task PushAsync(GitPushOptions gitPushOptions);
         public abstract Task ArchiveAsync(string targetDirectory, bool keepInternals = false);
         public abstract Task<IEnumerable<string>> EnumerateRemoteBranchesAsync();
         public abstract Task TagAsync(string tag, string commit, string message, bool force = false);

--- a/Git/Common/Clients/GitCloneOptions.cs
+++ b/Git/Common/Clients/GitCloneOptions.cs
@@ -11,6 +11,7 @@ namespace Inedo.Extensions.Clients
 
         public string Branch { get; set; }
         public bool RecurseSubmodules { get; set; }
+        public bool IsBare { get; set; }
 
         public override string ToString()
         {

--- a/Git/Common/Clients/GitPushOptions.cs
+++ b/Git/Common/Clients/GitPushOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Inedo.Extensions.Clients
+{
+    [Serializable]
+    public sealed class GitPushOptions
+    {
+        public GitPushOptions()
+        {
+        }
+
+        public string Ref { get; set; }
+        public bool Force { get; set; }
+    }
+}

--- a/Git/Common/Clients/GitUpdateOptions.cs
+++ b/Git/Common/Clients/GitUpdateOptions.cs
@@ -12,5 +12,6 @@ namespace Inedo.Extensions.Clients
         public string Ref { get; set; }
         public string Branch { get; set; }
         public bool RecurseSubmodules { get; set; }
+        public bool IsBare { get; set; }
     }
 }

--- a/Git/Common/Clients/LibGitSharp/LibGitSharpClient.cs
+++ b/Git/Common/Clients/LibGitSharp/LibGitSharpClient.cs
@@ -14,11 +14,6 @@ namespace Inedo.Extensions.Clients.LibGitSharp
         private static Task Complete => Task.FromResult<object>(null);
         private static readonly LfsFilter lfsFilter = new LfsFilter("lfs", new[] { new FilterAttributeEntry("lfs") });
 
-        static LibGitSharpClient()
-        {
-            GlobalSettings.RegisterFilter(lfsFilter);
-        }
-
         public LibGitSharpClient(GitRepositoryInfo repository, ILogSink log)
             : base(repository, log)
         {
@@ -203,6 +198,8 @@ namespace Inedo.Extensions.Clients.LibGitSharp
         {
             try
             {
+                this.BeginOperation();
+
                 this.log.LogDebug($"Using repository at '{this.repository.LocalRepositoryPath}'...");
                 using (var repository = new Repository(this.repository.LocalRepositoryPath))
                 {

--- a/Git/Common/Clients/LibGitSharp/Remote/ClientCommand.cs
+++ b/Git/Common/Clients/LibGitSharp/Remote/ClientCommand.cs
@@ -8,6 +8,7 @@
         EnumerateRemoteBranches,
         IsRepositoryValid,
         Tag,
-        Update
+        Update,
+        Push
     }
 }

--- a/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpClient.cs
+++ b/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpClient.cs
@@ -75,6 +75,14 @@ namespace Inedo.Extensions.Clients.LibGitSharp.Remote
             ).ConfigureAwait(false);
         }
 
+        public override Task PushAsync(GitPushOptions options)
+        {
+            return this.ExecuteRemoteAsync(
+                ClientCommand.Push,
+                new RemoteLibGitSharpContext { PushOptions = options }
+            );
+        }
+
         private async Task<object> ExecuteRemoteAsync(ClientCommand command, RemoteLibGitSharpContext context)
         {
             context.WorkingDirectory = this.workingDirectory;

--- a/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpContext.cs
+++ b/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpContext.cs
@@ -24,6 +24,7 @@ namespace Inedo.Extensions.Clients.LibGitSharp.Remote
         public string Commit { get; set; }
         public string TagMessage { get; set; }
         public GitUpdateOptions UpdateOptions { get; set; }
+        public GitPushOptions PushOptions { get; set; }
         public bool Force { get; set; }
     }
 }

--- a/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpJob.cs
+++ b/Git/Common/Clients/LibGitSharp/Remote/RemoteLibGitSharpJob.cs
@@ -52,6 +52,10 @@ namespace Inedo.Extensions.Clients.LibGitSharp.Remote
                 case ClientCommand.Update:
                     return await client.UpdateAsync(this.Context.UpdateOptions).ConfigureAwait(false);
 
+                case ClientCommand.Push:
+                    await client.PushAsync(this.Context.PushOptions).ConfigureAwait(false);
+                    return null;
+
                 default:
                     throw new InvalidOperationException("Invalid remote LibGitSharp job type: " + this.Command);
             }

--- a/Git/Common/Common.projitems
+++ b/Git/Common/Common.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Clients\CommandLine\GitCommandLineClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Clients\CommandLine\ProcessResults.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Clients\GitClient.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Clients\GitPushOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Clients\GitUpdateOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Clients\GitCloneOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Clients\GitRepositoryInfo.cs" />

--- a/Git/Common/Operations/TagOperation.cs
+++ b/Git/Common/Operations/TagOperation.cs
@@ -73,6 +73,13 @@ namespace Inedo.Extensions.Operations
             ).ConfigureAwait(false);
 
             await client.TagAsync(this.Tag, this.CommitHash, this.TagMessage, this.Force).ConfigureAwait(false);
+            await client.PushAsync(
+                new GitPushOptions
+                {
+                    Ref = this.Tag,
+                    Force = this.Force
+                }
+            ).ConfigureAwait(false);
 
             this.LogInformation("Tag complete.");
         }

--- a/Git/Git.InedoExtension/Git.InedoExtension.csproj
+++ b/Git/Git.InedoExtension/Git.InedoExtension.csproj
@@ -67,6 +67,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>

--- a/Git/Git.InedoExtension/packages.config
+++ b/Git/Git.InedoExtension/packages.config
@@ -3,4 +3,5 @@
   <package id="Inedo.SDK" version="1.0.4" targetFramework="net452" />
   <package id="LibGit2Sharp" version="0.24.0" targetFramework="net45" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- Use the command-line version of git if it is configured for the local agent. The detection for this is very hacky, but it shouldn't cause crashes. This will allow the use of SSH keys (if installed locally) for git rafts, as well as third-party git-remote-foo implementations.
- Improve commit messages to include a summary of the changes instead of just "Updated by [product name]."
- Try to connect to the external repository when testing raft configuration instead of just checking if the URL is formatted in a valid way.