### PR TITLE
Fix branch list variables not receiving values from credentials.

### DIFF
--- a/Git/GitHub.InedoExtension/ListVariableSources/BranchListVariableSource.cs
+++ b/Git/GitHub.InedoExtension/ListVariableSources/BranchListVariableSource.cs
@@ -70,6 +70,8 @@ namespace Inedo.Extensions.GitHub.ListVariableSources
 
         public override Task<IEnumerable<string>> EnumerateValuesAsync(ValueEnumerationContext context)
         {
+            this.SetValues();
+
             var client = new GitHubClient(this.ApiUrl, this.UserName, this.Password, this.OrganizationName);
 
             return client.ListRefsAsync(this.OrganizationName, this.RepositoryName, RefType.Branch, CancellationToken.None);

--- a/Git/GitLab.InedoExtension/Credentials/GitLabCredentials.cs
+++ b/Git/GitLab.InedoExtension/Credentials/GitLabCredentials.cs
@@ -13,6 +13,7 @@ namespace Inedo.Extensions.GitLab.Credentials
     [ScriptAlias("GitLab")]
     [DisplayName("GitLab")]
     [Description("Credentials for GitLab.")]
+    [PersistFrom("Inedo.Extensions.Credentials.GitLabCredentials,GitLab")]
     public sealed class GitLabCredentials : GitCredentialsBase
     {
         [Persistent]

--- a/Git/GitLab.InedoExtension/ListVariableSources/BranchListVariableSource.cs
+++ b/Git/GitLab.InedoExtension/ListVariableSources/BranchListVariableSource.cs
@@ -70,6 +70,8 @@ namespace Inedo.Extensions.GitLab.ListVariableSources
 
         public override async Task<IEnumerable<string>> EnumerateValuesAsync(ValueEnumerationContext context)
         {
+            this.SetValues();
+
             var client = new GitLabClient(this.ApiUrl, this.UserName, this.Password, this.GroupName);
 
             return await client.GetBranchesAsync(this.ProjectName, CancellationToken.None);


### PR DESCRIPTION
Handle loading old serialized GitLabCredentials

Force TLS 1.2 support for GitLab even if GitHub is not loaded.